### PR TITLE
We should log a blank listen address.

### DIFF
--- a/httpx/http_server.go
+++ b/httpx/http_server.go
@@ -2,7 +2,6 @@ package httpx
 
 import (
 	"crypto/tls"
-	"fmt"
 	"io/ioutil"
 	"log"
 	"net/http"
@@ -56,7 +55,6 @@ func (this *HTTPServer) WithTLS(certificatePEM string, tlsConfig *tls.Config) *H
 }
 
 func (this *HTTPServer) Listen() {
-	fmt.Println("HI")
 	if this == nil {
 		return
 	}
@@ -64,8 +62,6 @@ func (this *HTTPServer) Listen() {
 	log.Printf("[INFO] Listening for web traffic on %s.\n", this.inner.Addr)
 	if err := this.listen(); err != nil {
 		log.Fatal("[ERROR] Unable to listen to web traffic: ", err)
-	} else {
-		fmt.Println("NO ERROR!")
 	}
 }
 func (this *HTTPServer) listen() error {

--- a/httpx/http_server.go
+++ b/httpx/http_server.go
@@ -2,6 +2,7 @@ package httpx
 
 import (
 	"crypto/tls"
+	"fmt"
 	"io/ioutil"
 	"log"
 	"net/http"
@@ -15,6 +16,7 @@ type HTTPServer struct {
 
 func NewHTTPServer(listenAddress string, handler http.Handler) *HTTPServer {
 	if len(listenAddress) == 0 {
+		log.Println("[WARN] Blank listenAddress provided. No HTTPServer will be constructed.")
 		return nil
 	}
 
@@ -54,6 +56,7 @@ func (this *HTTPServer) WithTLS(certificatePEM string, tlsConfig *tls.Config) *H
 }
 
 func (this *HTTPServer) Listen() {
+	fmt.Println("HI")
 	if this == nil {
 		return
 	}
@@ -61,6 +64,8 @@ func (this *HTTPServer) Listen() {
 	log.Printf("[INFO] Listening for web traffic on %s.\n", this.inner.Addr)
 	if err := this.listen(); err != nil {
 		log.Fatal("[ERROR] Unable to listen to web traffic: ", err)
+	} else {
+		fmt.Println("NO ERROR!")
 	}
 }
 func (this *HTTPServer) listen() error {


### PR DESCRIPTION
The call to .Listen() will exit without any error if the listenAddress provided to NewHTTPServer is blank. This could cause a process to exit without error or any log messages.
